### PR TITLE
Remove gradients from documentation theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@
 body {
   min-height: 100vh;
   margin: 0;
-  background: linear-gradient(160deg, #05090f 0%, #04060c 55%, #030508 100%);
+  background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-sans);
   font-size: 1.0625rem;
@@ -62,11 +62,9 @@ body::before {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 12% -10%, rgba(249, 115, 22, 0.18) 0%, transparent 55%),
-    radial-gradient(circle at 85% -15%, rgba(59, 130, 246, 0.16) 0%, transparent 60%),
-    radial-gradient(circle at 12% 110%, rgba(15, 118, 110, 0.18) 0%, transparent 65%);
-  opacity: 0.22;
-  filter: blur(120px);
+  background-color: rgba(249, 115, 22, 0.06);
+  opacity: 0.18;
+  filter: blur(140px);
   mix-blend-mode: normal;
   z-index: -3;
 }
@@ -77,8 +75,8 @@ body::after {
   inset: 0;
   pointer-events: none;
   z-index: -2;
-  background: radial-gradient(circle at 50% 120%, rgba(2, 6, 23, 0.8) 0%, transparent 70%);
-  opacity: 0.28;
+  background-color: rgba(2, 6, 23, 0.75);
+  opacity: 0.2;
 }
 
 @keyframes float-orbs {
@@ -371,7 +369,7 @@ button,
   text-transform: uppercase;
   border-radius: 999px;
   border: none;
-  background: linear-gradient(135deg, rgba(249, 115, 22, 0.92), rgba(248, 191, 96, 0.95));
+  background-color: var(--color-primary);
   color: var(--color-primary-foreground);
   box-shadow: var(--shadow-primary);
   transition: var(--transition-standard);
@@ -495,7 +493,7 @@ code {
 }
 
 pre {
-  background: linear-gradient(165deg, rgba(5, 11, 20, 0.96) 0%, rgba(7, 14, 26, 0.98) 55%, rgba(4, 9, 18, 0.98) 100%);
+  background-color: rgba(5, 11, 20, 0.96);
   color: #e2e8f0;
   border: 1px solid rgba(148, 163, 184, 0.18);
   padding: 1.5rem;


### PR DESCRIPTION
## Summary
- replace body and overlay backgrounds with solid colors to eliminate gradients
- update primary button and code block styling to use flat fills instead of gradients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2bff9cc4c832a876b80015d78c25c