### PR TITLE
Refresh docs light theming and spacing

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -20,11 +20,6 @@
       "url": "https://app.agentflare.com"
     },
     {
-      "name": "GitHub",
-      "icon": "github",
-      "url": "https://github.com/agentflare-ai"
-    },
-    {
       "name": "Early Access",
       "icon": "rocket",
       "url": "https://agentflare.com/early-access"
@@ -99,8 +94,8 @@
   },
   "background": {
     "color": {
-      "light": "#ffffff",
-      "dark": "#09131a"
+      "light": "#f3f6f9",
+      "dark": "#f3f6f9"
     }
   },
   "navbar": {
@@ -108,10 +103,6 @@
       {
         "label": "Dashboard",
         "href": "https://app.agentflare.com"
-      },
-      {
-        "label": "GitHub",
-        "href": "https://github.com/agentflare-ai"
       }
     ],
     "primary": {

--- a/style.css
+++ b/style.css
@@ -1,80 +1,41 @@
-/* Agentflare Documentation - Mintlify Dark Theme */
-/* Implements Agentflare Design System guidelines */
-
-/* Font Loading */
+/* Agentflare Documentation - Light Theme Refresh */
 @import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Geist:wght@200;300;400;500;600;700;800&family=Geist+Mono:wght@400;500;600;700&display=swap');
 
 :root {
-  /* Typography */
-  --font-sans: "Geist", "Geist Sans", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-sans: "Geist", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "Geist Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-display: "Bebas Neue", "Geist", sans-serif;
 
-  /* Core palette */
   --color-primary: #f97316;
   --color-primary-foreground: #ffffff;
-  --color-background: #09131a;
-  --color-background-elevated: #121c23;
-  --color-foreground: #e2e8f0;
-  --color-foreground-subtle: #cbd5f5;
-  --color-card: #121c23;
-  --color-secondary: #121c23;
-  --color-muted: #121c23;
-  --color-muted-foreground: #94a3b8;
-  --color-border: rgba(148, 163, 184, 0.28);
-  --color-border-subtle: rgba(148, 163, 184, 0.12);
-  --color-ring: rgba(249, 115, 22, 0.65);
-  --color-header: #121c23;
-  --color-header-border: rgba(148, 163, 184, 0.16);
-
-  /* Accent palette for charts */
-  --chart-1: #f97316;
-  --chart-2: #8b5cf6;
-  --chart-3: #22d3ee;
-  --chart-4: #22c55e;
-  --chart-5: #f472b6;
-
-  --shadow-primary: none;
-  --shadow-elevated: none;
-  --transition-standard: all 0.35s ease;
-  --content-max-width: min(100%, 1360px);
+  --color-background: #f3f6f9;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8fafc;
+  --color-text: #09131a;
+  --color-text-muted: #475569;
+  --color-border: #d7e0e9;
+  --color-border-strong: #b6c2cf;
+  --color-code-background: #1f2933;
+  --shadow-soft: 0 12px 24px rgba(15, 23, 42, 0.06);
+  --content-max-width: min(100%, 1280px);
 }
 
-/* Global layout */
+html,
 body {
-  min-height: 100vh;
-  margin: 0;
-  background-color: var(--color-background);
-  color: var(--color-foreground);
+  background: var(--color-background);
+  color: var(--color-text);
   font-family: var(--font-sans);
-  font-size: 1.0625rem;
-  line-height: 1.75;
+  font-size: 1.05rem;
+  line-height: 1.7;
   letter-spacing: -0.01em;
+  margin: 0;
+  min-height: 100vh;
+}
+
+body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: relative;
-  overflow-x: hidden;
-}
-
-@keyframes float-orbs {
-  0% {
-    transform: translate3d(-2%, 1%, 0) scale(1.02);
-  }
-  100% {
-    transform: translate3d(2%, -1%, 0) scale(0.98);
-  }
-}
-
-/* Subtle grain texture overlay */
-body::selection,
-body *::selection {
-  background: color-mix(in oklab, var(--color-primary) 60%, transparent);
-  color: var(--color-primary-foreground);
-}
-
-body::backdrop {
-  backdrop-filter: blur(4px);
 }
 
 main,
@@ -85,6 +46,7 @@ main,
   display: flex;
   flex: 1 1 auto;
   justify-content: center;
+  background: var(--color-background);
 }
 
 .content-container,
@@ -92,25 +54,32 @@ main,
 main > div {
   width: 100%;
   max-width: var(--content-max-width);
-  padding: 5rem 1.5rem;
+  padding: 4rem 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 3rem;
 }
 
-/* Header & Navigation */
+@media (max-width: 768px) {
+  .content-container,
+  .layout,
+  main > div {
+    padding: 3rem 1.5rem;
+  }
+}
+
 header,
 .mintlify-header,
 .top-nav,
 .navbar,
 .docs-navbar {
-  background: var(--color-header);
-  border-bottom: 1px solid var(--color-header-border);
-  backdrop-filter: blur(18px);
-  box-shadow: var(--shadow-elevated);
+  background: var(--color-surface) !important;
+  background-image: none !important;
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: none;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
 }
 
 header .logo,
@@ -124,19 +93,18 @@ header .logo,
   font-size: 1.125rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--color-foreground);
+  color: var(--color-text);
 }
 
 header nav a,
 .navbar a,
 .top-nav a,
 .docs-navbar a {
-  color: color-mix(in srgb, var(--color-foreground) 75%, transparent);
+  color: var(--color-text-muted);
   font-weight: 500;
-  letter-spacing: 0.02em;
   padding: 0.75rem 1rem;
-  border-radius: 0;
-  transition: var(--transition-standard);
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
 header nav a:hover,
@@ -147,63 +115,45 @@ header nav a.active,
 .navbar a.active,
 .top-nav a.active,
 .docs-navbar a.active {
-  color: var(--color-foreground);
-  background: rgba(15, 118, 110, 0.18);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.24);
+  color: var(--color-text);
+  background: var(--color-surface-muted);
 }
 
-header .actions button,
+header button,
 .mintlify-header button,
 .top-nav button,
 .docs-navbar button {
-  background: #121c23;
-  color: #ffffff;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 0;
-  padding: 0.6rem 1.1rem;
-  font-size: 0.8125rem;
-  letter-spacing: 0.08em;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  box-shadow: none;
+  border-radius: 999px;
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+  padding: 0.65rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-header .actions button:hover,
+header button:hover,
 .mintlify-header button:hover,
 .top-nav button:hover,
 .docs-navbar button:hover {
-  border-color: rgba(249, 115, 22, 0.6);
-  color: #ffffff;
-  background: #09131a;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
 }
 
-.search-input,
-input[type="search"],
-.mintlify-search-input {
-  background: #121c23 !important;
-  border: 1px solid rgba(148, 163, 184, 0.28) !important;
-  color: var(--color-foreground) !important;
-  border-radius: 0 !important;
-  padding-inline: 1.25rem !important;
-  transition: var(--transition-standard);
-  box-shadow: none !important;
+.theme-toggle,
+button[aria-label*="Toggle"],
+button[aria-label*="toggle"],
+button[data-theme-toggle],
+button[data-theme="toggle"],
+.mintlify-header [data-theme-toggle],
+.mintlify-header .theme-toggle {
+  display: none !important;
 }
 
-.search-input:focus,
-input[type="search"]:focus,
-.mintlify-search-input:focus {
-  border-color: rgba(249, 115, 22, 0.55) !important;
-  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.2) !important;
-}
-
-@media (min-width: 1024px) {
-  .content-container,
-  .layout,
-  main > div {
-    padding-inline: 3rem;
-  }
-}
-
-/* Typography */
 h1,
 h2,
 h3,
@@ -211,35 +161,34 @@ h4,
 h5,
 h6 {
   font-family: var(--font-sans);
-  letter-spacing: -0.02em;
-  color: var(--color-foreground);
+  color: var(--color-text);
   margin: 0;
 }
 
 h1 {
-  font-size: clamp(2.75rem, 2.5rem + 1.5vw, 3rem);
-  font-weight: 300;
-  color: var(--color-foreground);
+  font-size: clamp(2.5rem, 2.1rem + 1.5vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
 }
 
 h2 {
-  font-size: clamp(2rem, 1.65rem + 0.8vw, 1.875rem);
+  font-size: clamp(2rem, 1.75rem + 0.8vw, 2.5rem);
   font-weight: 600;
-  color: var(--color-primary);
+  letter-spacing: -0.02em;
 }
 
 h3 {
-  font-size: clamp(1.5rem, 1.35rem + 0.5vw, 1.5rem);
+  font-size: clamp(1.6rem, 1.45rem + 0.5vw, 2rem);
   font-weight: 600;
 }
 
 h4 {
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   font-weight: 600;
 }
 
 h5 {
-  font-size: 1.125rem;
+  font-size: 1.15rem;
   font-weight: 600;
 }
 
@@ -248,134 +197,168 @@ ul,
 ol,
 li,
 blockquote {
-  color: rgba(226, 232, 240, 0.88);
+  color: var(--color-text-muted);
 }
 
-small,
-.caption,
-label {
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted-foreground) 85%, transparent);
-}
-
-/* Links */
 a {
   color: var(--color-primary);
-  position: relative;
-  transition: var(--transition-standard);
   text-decoration: none;
-}
-
-a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: -0.2rem;
-  width: 0;
-  height: 1px;
-  background: var(--color-primary);
-  transition: width 0.4s ease;
+  transition: color 0.2s ease;
 }
 
 a:hover {
-  color: color-mix(in oklab, var(--color-primary) 90%, var(--color-foreground) 10%);
+  color: #ef6510;
 }
 
-a:hover::after {
-  width: 100%;
-}
-
-/* Lists */
 ul,
 ol {
   padding-left: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 li::marker {
   color: var(--color-primary);
 }
 
-/* Blockquote */
 blockquote {
-  border-left: 3px solid rgba(148, 163, 184, 0.4);
-  background: #121c23;
-  padding: 1.25rem 1.5rem;
-  font-style: italic;
-  color: rgba(226, 232, 240, 0.8);
-  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+  margin: 0;
+  padding: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  border-radius: 12px;
 }
 
-/* Cards & Surfaces */
-.card,
+section,
+.content-section,
+.docs-section,
+.mintlify-section,
+main section,
+article section {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  margin: 0;
+}
+
+section > :first-child {
+  margin-top: 0;
+}
+
+section > :last-child {
+  margin-bottom: 0;
+}
+
 .callout,
 .admonition,
+.card,
 .popover,
-.mintlify-callout {
-  background: #121c23;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 0;
-  backdrop-filter: blur(12px);
-  box-shadow: var(--shadow-elevated);
-  transition: var(--transition-standard);
-}
-
-.card:hover,
-.callout:hover,
-.popover:hover,
-.mintlify-callout:hover {
-  border-color: rgba(249, 115, 22, 0.4);
-  box-shadow: var(--shadow-primary);
-}
-
-/* Buttons */
-button,
-.button,
-.btn,
-.mintlify-button,
-.button-primary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1rem 2rem;
-  font-family: var(--font-sans);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border-radius: 0;
-  border: none;
-  background-color: var(--color-primary);
-  color: var(--color-primary-foreground);
-  box-shadow: var(--shadow-primary);
-  transition: var(--transition-standard);
-}
-
-button:hover,
-.button:hover,
-.btn:hover,
-.mintlify-button:hover,
-.button-primary:hover {
-  filter: brightness(1.05);
-  transform: translateY(-2px);
-}
-
-.button-secondary,
-.btn-secondary,
-button.secondary {
-  background: #121c23;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  color: #ffffff;
+.mintlify-callout,
+.mintlify-card,
+.mintlify-admonition,
+.mintlify-popover {
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  color: var(--color-text-muted);
   box-shadow: none;
 }
 
-.button-secondary:hover,
-.btn-secondary:hover,
-button.secondary:hover {
-  border-color: rgba(249, 115, 22, 0.45);
-  background: #09131a;
+.badge,
+.tag,
+.label,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  background: rgba(249, 115, 22, 0.14);
+  border: 1px solid rgba(249, 115, 22, 0.4);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mintlify-search-input,
+.search-input,
+input[type="search"],
+input,
+textarea,
+select {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mintlify-search-input:focus,
+.search-input:focus,
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.16);
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  overflow: hidden;
+  margin: 1rem 0;
+}
+
+th,
+td {
+  padding: 1rem;
+  text-align: left;
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+}
+
+th {
+  background: var(--color-surface-muted);
+  font-weight: 600;
+}
+
+tr:last-child td,
+tr:last-child th {
+  border-bottom: none;
+}
+
+pre,
+code,
+.mintlify-code,
+.code-block {
+  font-family: var(--font-mono);
+  background: var(--color-code-background);
+  color: #f8fafc;
+}
+
+pre,
+.code-block {
+  padding: 1.25rem;
+  border-radius: 14px;
+  overflow-x: auto;
+}
+
+code {
+  border-radius: 8px;
+  padding: 0.25rem 0.45rem;
 }
 
 button[aria-label*="Copy"],
@@ -384,15 +367,14 @@ button.copy-button,
 .copy-button button,
 .code-block button,
 pre button {
-  background: #121c23 !important;
-  border: 1px solid rgba(148, 163, 184, 0.35) !important;
-  color: #ffffff !important;
-  border-radius: 0 !important;
+  background: rgba(15, 23, 42, 0.85) !important;
+  border: 1px solid rgba(15, 23, 42, 0.6) !important;
+  color: #f8fafc !important;
+  border-radius: 999px !important;
   padding: 0.45rem 0.9rem !important;
   font-size: 0.75rem !important;
   letter-spacing: 0.08em !important;
   text-transform: uppercase !important;
-  box-shadow: none !important;
 }
 
 button[aria-label*="Copy"]:hover,
@@ -401,263 +383,56 @@ button.copy-button:hover,
 .copy-button button:hover,
 .code-block button:hover,
 pre button:hover {
-  border-color: rgba(249, 115, 22, 0.45) !important;
-  color: #ffffff !important;
-  background: #09131a !important;
+  filter: brightness(1.1);
 }
 
-/* Inputs */
-input,
-textarea,
-select,
-.search-input,
-input[type="search"] {
-  background: var(--color-secondary);
-  border: 1px solid color-mix(in oklab, var(--color-border) 80%, transparent);
-  color: var(--color-foreground);
-  border-radius: 0;
-  padding: 0.75rem 1rem;
-  transition: var(--transition-standard);
-}
-
-input:focus,
-textarea:focus,
-select:focus,
-.search-input:focus,
-input[type="search"]:focus {
-  outline: 2px solid color-mix(in oklab, var(--color-ring) 80%, transparent);
-  outline-offset: 2px;
-  border-color: var(--color-ring);
-  box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-ring) 30%, transparent);
-}
-
-/* Tables */
-table {
-  width: 100%;
-  border-collapse: collapse;
-  background: #121c23;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: 0;
-  overflow: hidden;
-}
-
-thead th {
-  background: #121c23;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-  padding: 0.9rem 1rem;
-  color: var(--color-foreground-subtle);
-}
-
-tbody tr {
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-  transition: var(--transition-standard);
-}
-
-tbody tr:hover {
-  background: #09131a;
-}
-
-td {
-  padding: 0.9rem 1rem;
-  color: rgba(226, 232, 240, 0.85);
-}
-
-/* Code Blocks */
-pre,
-code {
-  font-family: var(--font-mono);
-}
-
-pre {
-  background-color: #121c23;
-  color: #e2e8f0;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  padding: 1.5rem;
-  overflow-x: auto;
-  border-radius: 0;
-  position: relative;
-}
-
-pre code {
-  counter-reset: line;
-  display: block;
-}
-
-pre code > span {
-  display: block;
-  position: relative;
-  padding-left: 3.25rem;
-}
-
-pre code > span::before {
-  counter-increment: line;
-  content: counter(line);
-  position: absolute;
-  left: 0;
-  width: 2.75rem;
-  text-align: right;
-  padding-right: 0.9rem;
-  color: rgba(148, 163, 184, 0.55);
-  background: transparent;
-  border-right: 1px solid rgba(148, 163, 184, 0.12);
-}
-
-code:not(pre code) {
-  background: #121c23;
-  padding: 0.25rem 0.45rem;
-  color: var(--color-foreground-subtle);
-  border-radius: 0;
-  font-size: 0.95em;
-}
-
-/* Badges */
-.badge,
-.tag,
-.label,
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  border-radius: 0;
-  padding: 0.4rem 0.9rem;
-  background: rgba(249, 115, 22, 0.12);
-  border: 1px solid rgba(249, 115, 22, 0.35);
-  color: var(--color-foreground);
-  font-size: 0.875rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.badge::before,
-.tag::before,
-.label::before,
-.status-pill::before {
-  content: "";
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 0;
-  background: var(--color-primary);
-}
-
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--color-background);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--color-primary);
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in oklab, var(--color-primary) 90%, var(--color-primary-foreground) 10%);
-}
-
-/* Navigation */
 .sidebar,
 .nav-sidebar,
 nav {
-  background: #121c23;
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
-  backdrop-filter: blur(18px);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
 }
 
 .sidebar a,
 .nav-sidebar a {
-  color: color-mix(in srgb, var(--color-foreground) 80%, transparent);
+  color: var(--color-text-muted);
   padding: 0.65rem 1rem;
-  border-left: 0 solid transparent;
-  transition: var(--transition-standard);
-  border-radius: 0;
+  border-radius: 12px;
+  transition: color 0.2s ease, background 0.2s ease;
 }
 
 .sidebar a:hover,
-.nav-sidebar a:hover {
-  color: var(--color-foreground);
-  border-left-width: 0;
-  background: rgba(15, 118, 110, 0.15);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
-}
-
+.nav-sidebar a:hover,
 .sidebar a.active,
 .nav-sidebar a.active {
-  color: var(--color-foreground);
-  background: rgba(249, 115, 22, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(249, 115, 22, 0.45);
+  color: var(--color-text);
+  background: var(--color-surface-muted);
 }
 
-/* Grid overlay */
-@keyframes grid-shift {
-  0% {
-    transform: translate3d(0, 0, 0);
-  }
-  100% {
-    transform: translate3d(80px, 80px, 0);
-  }
-}
-
-/* Utility classes */
-.text-foreground {
-  color: var(--color-foreground) !important;
-}
-
-.text-foreground-muted {
-  color: color-mix(in oklab, var(--color-foreground) 70%, transparent) !important;
-}
-
-.text-primary {
-  color: var(--color-primary) !important;
-}
-
-.bg-card {
-  background: var(--color-card) !important;
-}
-
-.border-primary {
-  border-color: var(--color-primary) !important;
-}
-
-.border-muted {
-  border-color: color-mix(in oklab, var(--color-border) 60%, transparent) !important;
-}
-
-.shadow-primary {
-  box-shadow: var(--shadow-primary) !important;
-}
-
-/* Focus states */
-*:focus-visible {
-  outline: 2px solid var(--color-ring);
-  outline-offset: 2px;
-}
-
-/* Mermaid diagrams */
 .mermaid {
-  background: #121c23;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
   padding: 1.5rem;
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-soft);
+  color: var(--color-text);
 }
 
 .mermaid .node rect,
 .mermaid .node circle,
 .mermaid .node ellipse {
-  stroke: rgba(148, 163, 184, 0.55);
-  fill: #121c23;
+  fill: var(--color-surface-muted);
+  stroke: var(--color-border-strong);
+}
+
+.mermaid .cluster rect {
+  fill: var(--color-surface);
+  stroke: var(--color-border-strong);
 }
 
 .mermaid .node text,
 .mermaid .label text {
-  fill: var(--color-foreground);
+  fill: #09131a !important;
 }
 
 .mermaid .edgePath .path,
@@ -666,37 +441,39 @@ nav {
   stroke-width: 2;
 }
 
-  .mermaid .cluster rect {
-    fill: #121c23;
-    stroke: rgba(148, 163, 184, 0.35);
-    rx: 0;
-    ry: 0;
-  }
-
-/* Media queries */
-@media (max-width: 768px) {
-  body {
-    font-size: 1rem;
-  }
-
-  h1 {
-    font-size: 2.5rem;
-  }
-
-  .content-container,
-  .layout,
-  main > div {
-    padding: 4rem 1.25rem;
-  }
+footer,
+.mintlify-footer {
+  background: var(--color-background);
+  color: var(--color-text-muted);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
+html[data-theme="dark"],
+html[data-theme="dark"] body,
+html[data-theme="dark"] header,
+html[data-theme="dark"] .mintlify-header,
+html[data-theme="dark"] .top-nav,
+html[data-theme="dark"] .navbar,
+html[data-theme="dark"] .docs-navbar {
+  background: var(--color-background) !important;
+  color: var(--color-text) !important;
+}
+
+html[data-theme="dark"] section,
+html[data-theme="dark"] .content-section,
+html[data-theme="dark"] .docs-section,
+html[data-theme="dark"] .mintlify-section,
+html[data-theme="dark"] table,
+html[data-theme="dark"] .mermaid {
+  background: var(--color-surface) !important;
+  color: var(--color-text) !important;
+}
+
+*::selection {
+  background: rgba(249, 115, 22, 0.25);
+  color: var(--color-text);
+}
+
+*:focus-visible {
+  outline: 2px solid rgba(249, 115, 22, 0.8);
+  outline-offset: 3px;
 }


### PR DESCRIPTION
## Summary
- restyle the documentation for a light-only theme with consistent typography and surfaces
- ensure sections and tables include at least 16px padding and flowchart text uses #09131a on light backgrounds
- remove the GitHub header link, disable the dark-mode toggle, and align the header background with the page background

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2c520ff7c832a827cdffe75d09ac0