### PR TITLE
Fix sidebar alignment and default text color overrides

### DIFF
--- a/style.css
+++ b/style.css
@@ -295,8 +295,10 @@ html[data-mode="light"],
   .layout,
   .mintlify-layout {
     display: flex;
+    flex-direction: row;
     align-items: flex-start;
-    column-gap: 3rem;
+    justify-content: space-between;
+    gap: 3rem;
   }
 
   .page-wrapper > .sidebar,
@@ -307,22 +309,21 @@ html[data-mode="light"],
   .mintlify-layout > nav {
     position: sticky;
     top: calc(var(--header-height) + 1.5rem);
-    align-self: flex-start;
     flex: 0 0 clamp(240px, 22vw, 300px);
+    width: clamp(240px, 22vw, 300px);
     max-width: clamp(240px, 22vw, 320px);
-    margin-right: 0;
     height: max-content;
+    margin-inline-start: 0;
+    order: 1;
     z-index: 3;
   }
 
-  .page-wrapper > .sidebar + *,
-  .layout > .sidebar + *,
-  .mintlify-layout > .sidebar + *,
-  .page-wrapper > nav + *,
-  .layout > nav + *,
-  .mintlify-layout > nav + * {
-    flex: 1 1 0;
+  .page-wrapper > :not(.sidebar):not(nav),
+  .layout > :not(.sidebar):not(nav),
+  .mintlify-layout > :not(.sidebar):not(nav) {
+    flex: 1 1 0%;
     min-width: 0;
+    order: 0;
   }
 }
 
@@ -371,7 +372,7 @@ ul,
 ol,
 li,
 blockquote {
-  color: rgba(226, 232, 240, 0.88);
+  color: var(--color-foreground);
 }
 
 small,
@@ -428,7 +429,7 @@ blockquote {
   background: #121c23;
   padding: 1.25rem 1.5rem;
   font-style: italic;
-  color: rgba(226, 232, 240, 0.8);
+  color: var(--color-foreground);
   box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
 }
 
@@ -636,7 +637,7 @@ tbody tr:hover {
 
 td {
   padding: var(--table-cell-padding);
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--color-foreground);
 }
 
 /* Code Blocks */


### PR DESCRIPTION
## Summary
- switch the large-screen docs layout to a row-based flex arrangement so the sticky sidebar renders to the right of the content instead of underneath it
- let blockquotes and table cells inherit the standard foreground color so custom flowchart text colors are not overridden

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e2d4b118d8832a85061d617b420d74