### PR TITLE
Rebalance content area spacing beside sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,6 +45,7 @@
   --shadow-elevated: none;
   --transition-standard: all 0.35s ease;
   --content-max-width: min(100%, 1360px);
+  --content-lateral-offset: clamp(2.5rem, 2rem + 1vw, 3.25rem);
 }
 *,
 *::before,
@@ -127,6 +128,22 @@ main > div {
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
+}
+
+#content-area {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: var(--content-max-width);
+  box-sizing: border-box;
+  margin-inline: auto;
+  padding-inline: clamp(0.75rem, 0.5rem + 1vw, 1.5rem);
+  gap: clamp(2rem, 1.75rem + 0.5vw, 3rem);
+}
+
+#content-area > * {
+  min-width: 0;
 }
 
 /* Header & Navigation */
@@ -289,8 +306,6 @@ html[data-mode="light"],
   :root:has(.sidebar[hidden]),
   :root:has(.sidebar[style*="display: none"]),
   :root:has(.sidebar[data-state="closed"]),
-  :root:has(.sidebar[aria-hidden="true"]),
-  :root:has(.sidebar[aria-expanded="false"]),
   :root:has(body.sidebar-hidden),
   :root:has(body.sidebar-collapsed) {
     --sidebar-width: 0px;
@@ -311,6 +326,13 @@ html[data-mode="light"],
     gap: clamp(2rem, 1rem + 2vw, 3rem);
   }
 
+  #content-area {
+    max-width: min(100%, calc(var(--content-max-width) - var(--sidebar-width) + var(--content-lateral-offset)));
+    padding-inline-start: calc(var(--sidebar-width) + var(--content-lateral-offset));
+    padding-inline-end: var(--content-lateral-offset);
+    margin-inline-start: calc(-1 * var(--content-lateral-offset));
+  }
+
   .page-wrapper > .sidebar,
   .layout > .sidebar,
   .mintlify-layout > .sidebar,
@@ -321,12 +343,41 @@ html[data-mode="light"],
     top: calc(var(--header-height) + 1.5rem);
     width: var(--sidebar-width);
     max-width: var(--sidebar-width);
-    height: max-content;
+    min-width: 0;
+    height: calc(100vh - var(--header-height) - 1.5rem);
     margin-inline-start: 0;
     align-self: flex-start;
     grid-column: 1;
     grid-row: 1;
     z-index: 3;
+    display: block;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .page-wrapper > .sidebar > :where(nav, div),
+  .layout > .sidebar > :where(nav, div),
+  .mintlify-layout > .sidebar > :where(nav, div),
+  .page-wrapper > nav > :where(div, ul, nav),
+  .layout > nav > :where(div, ul, nav),
+  .mintlify-layout > nav > :where(div, ul, nav) {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding-inline-end: clamp(1.5rem, 1rem + 0.8vw, 2rem);
+    padding-block-end: clamp(2rem, 1.5rem + 1vw, 2.75rem);
+    scrollbar-gutter: stable both-edges;
+  }
+
+  .page-wrapper > .sidebar > :where(nav, div) > :where(nav, ul),
+  .layout > .sidebar > :where(nav, div) > :where(nav, ul),
+  .mintlify-layout > .sidebar > :where(nav, div) > :where(nav, ul),
+  .page-wrapper > nav > :where(div, nav) > ul,
+  .layout > nav > :where(div, nav) > ul,
+  .mintlify-layout > nav > :where(div, nav) > ul {
+    position: static;
   }
 
   .page-wrapper > :not(.sidebar):not(nav),
@@ -340,37 +391,32 @@ html[data-mode="light"],
   .page-wrapper:has(.sidebar[hidden]),
   .page-wrapper:has(.sidebar[style*="display: none"]),
   .page-wrapper:has(.sidebar[data-state="closed"]),
-  .page-wrapper:has(.sidebar[aria-hidden="true"]),
-  .page-wrapper:has(.sidebar[aria-expanded="false"]),
   .layout:has(.sidebar[hidden]),
   .layout:has(.sidebar[style*="display: none"]),
   .layout:has(.sidebar[data-state="closed"]),
-  .layout:has(.sidebar[aria-hidden="true"]),
-  .layout:has(.sidebar[aria-expanded="false"]),
   .mintlify-layout:has(.sidebar[hidden]),
   .mintlify-layout:has(.sidebar[style*="display: none"]),
-  .mintlify-layout:has(.sidebar[data-state="closed"]),
-  .mintlify-layout:has(.sidebar[aria-hidden="true"]),
-  .mintlify-layout:has(.sidebar[aria-expanded="false"]) {
+  .mintlify-layout:has(.sidebar[data-state="closed"]) {
     grid-template-columns: minmax(0, 1fr);
   }
 
   .page-wrapper:has(.sidebar[hidden]) > :not(.sidebar):not(nav),
   .page-wrapper:has(.sidebar[style*="display: none"]) > :not(.sidebar):not(nav),
   .page-wrapper:has(.sidebar[data-state="closed"]) > :not(.sidebar):not(nav),
-  .page-wrapper:has(.sidebar[aria-hidden="true"]) > :not(.sidebar):not(nav),
-  .page-wrapper:has(.sidebar[aria-expanded="false"]) > :not(.sidebar):not(nav),
   .layout:has(.sidebar[hidden]) > :not(.sidebar):not(nav),
   .layout:has(.sidebar[style*="display: none"]) > :not(.sidebar):not(nav),
   .layout:has(.sidebar[data-state="closed"]) > :not(.sidebar):not(nav),
-  .layout:has(.sidebar[aria-hidden="true"]) > :not(.sidebar):not(nav),
-  .layout:has(.sidebar[aria-expanded="false"]) > :not(.sidebar):not(nav),
   .mintlify-layout:has(.sidebar[hidden]) > :not(.sidebar):not(nav),
   .mintlify-layout:has(.sidebar[style*="display: none"]) > :not(.sidebar):not(nav),
-  .mintlify-layout:has(.sidebar[data-state="closed"]) > :not(.sidebar):not(nav),
-  .mintlify-layout:has(.sidebar[aria-hidden="true"]) > :not(.sidebar):not(nav),
-  .mintlify-layout:has(.sidebar[aria-expanded="false"]) > :not(.sidebar):not(nav) {
+  .mintlify-layout:has(.sidebar[data-state="closed"]) > :not(.sidebar):not(nav) {
     grid-column: 1;
+  }
+}
+
+@media (min-width: 1280px) {
+  #content-area {
+    max-width: min(100%, calc(var(--content-max-width) - 28rem));
+    padding-inline-end: calc(var(--content-lateral-offset) + 1.25rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable lateral offset variable to coordinate desktop spacing
- restyle the `#content-area` container so main content stays beside the fixed sidebar on wide screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2f4c5f454832a806f1012bd20033e