### PR TITLE
Adjust content-area spacing at xl breakpoint

### DIFF
--- a/style.css
+++ b/style.css
@@ -417,8 +417,7 @@ html[data-mode="light"],
 
 @media (min-width: 1280px) {
   #content-area {
-    max-width: min(100%, calc(var(--content-max-width) - 28rem));
-    padding-inline-end: calc(var(--content-lateral-offset) + 1.25rem);
+    padding-top: 2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove redundant max-width and inline-end padding overrides for the content area on extra-large screens
- introduce consistent top padding to the content area at the 1280px breakpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e302b2d0f4832a8d1cfbab0156ecb5