### PR TITLE
Add padding for inline tables

### DIFF
--- a/style.css
+++ b/style.css
@@ -710,6 +710,11 @@ table {
   padding: var(--surface-padding);
 }
 
+table[style*="display:inline-table"],
+table[style*="display: inline-table"] {
+  padding: 16px;
+}
+
 thead th {
   background: #121c23;
   border-bottom: 1px solid rgba(148, 163, 184, 0.2);


### PR DESCRIPTION
## Summary
- add a targeted CSS rule to provide padding for inline tables without affecting other tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e303c8bf88832a947f455762bbb5fe